### PR TITLE
If commentId is zero, add rather than update

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -100,7 +100,7 @@ async function run() {
 
     const octokit = github.getOctokit(inputs.token);
 
-    if (inputs.commentId) {
+    if ((inputs.commentId) && (inputs.commentId != 0)) {
       // Edit a comment
       if (!inputs.body && !inputs.reactions) {
         core.setFailed("Missing either comment 'body' or 'reactions'.");


### PR DESCRIPTION
Hiyo! Thank you so much for this action @peter-evans :bow:

I'm using create-or-update-comment to address https://github.com/solvaholic/octodns-sync/issues/41

Given how the `commentId` is checked now:

https://github.com/peter-evans/create-or-update-comment/blob/f18a20688400a6169e2597aae859071f6389e49e/dist/index.js#L103

It seems necessary to write separate workflow steps gated on `comment-id` in the find-comment output, to avoid an error when `comment-id` is zero.

If that check were more like "if commentId is set and it's not zero" then I think users could write one workflow step that will add a comment when `comment-id` is zero and update a comment when it's non-zero.

I tested the change I've submitted here over in https://github.com/solvaholic/scaling-succotash/pull/5

To me it looks great but idk about javascript actions. Two questions I have for you:

What do you think of running the update vs. add check this way?

What's the relationship between `index.js` and `dist/index.js` in this repository?