### PR TITLE
Use double quotes to preserve adjacent spaces correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,11 +164,11 @@ The content must be [escaped to preserve newlines](https://github.community/t/se
 ```yml
       - id: get-comment-body
         run: |
-          body=$(cat comment-body.txt)
+          body="$(cat comment-body.txt)"
           body="${body//'%'/'%25'}"
           body="${body//$'\n'/'%0A'}"
           body="${body//$'\r'/'%0D'}" 
-          echo ::set-output name=body::$body
+          echo "::set-output name=body::$body"
 
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v1


### PR DESCRIPTION
## Summary
I used this action as part of a workflow to add code formatted blocks.
Using the guide in the readme I, adjacent spaces where not correctly
preserved, i.e. the following
```
      - name: yolo
        id: get-comment-body
        run: |
          echo "\`\`\`" > tmp/comment.md
          echo "+--------------+" >> tmp/comment.md
          echo "|This is a test|" >> tmp/comment.md
          echo "+--------------+" >> tmp/comment.md
          echo "|     yolo     |" >> tmp/comment.md
          echo "+--------------+" >> tmp/comment.md
          echo "\`\`\`" >> tmp/comment.md

          cat tmp/comment.md

          # https://github.com/peter-evans/create-or-update-comment#setting-the-comment-body-from-a-file
          body="$(cat tmp/comment.md)"
          body="${body//'%'/'%25'}"
          body="${body//$'\n'/'%0A'}"
          body="${body//$'\r'/'%0D'}"
          echo ::set-output name=body::$body

      - name: Create or update comment
        uses: peter-evans/create-or-update-comment@v1
        with:
          body: ${{ steps.get-comment-body.outputs.body }}
          issue-number: ${{ github.event.pull_request.number }}
```
produced this
```
+--------------+
|This is a test|
+--------------+
| yolo |
+--------------+
```
Adding the double quotes around `set-output` fixed this:
```
+--------------+
|This is a test|
+--------------+
|     yolo     |
+--------------+
```
Further I added double quotes also around the initial `cat`, because of
this comment https://github.community/t/set-output-truncates-multiline-strings/16852/5
> Here are a few observation. First, it is important to suppress word-splitting upon expansion in bash. This is easiest done by enclosing with double quotes:

Thank you!