### PR TITLE
Check if body is greater than maximum comment length

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const { inspect } = require("util");
 const core = require("@actions/core");
 const github = require("@actions/github");
 
+const MAXIMUM_COMMENT_LENGTH = 65536;
 const REACTION_TYPES = [
   "+1",
   "-1",
@@ -88,6 +89,11 @@ async function run() {
     core.debug(`editMode: ${editMode}`);
     if (!["append", "replace"].includes(editMode)) {
       core.setFailed(`Invalid edit-mode '${editMode}'.`);
+      return;
+    }
+
+    if (inputs.body && inputs.body.length > MAXIMUM_COMMENT_LENGTH) {
+      core.setFailed(`Comment body is too long. Maximum length is ${MAXIMUM_COMMENT_LENGTH} characters.`);
       return;
     }
 


### PR DESCRIPTION
Add a check if inputs.body is greater than maximum github comment length.

I don't create a test because file should be too long.

I think it's better to return a fail, I thought of crushing the body by `Comment body is too long. Maximum length is ${MAXIMUM_COMMENT_LENGTH} characters.` so that you can see the error on the comment. What do you think about it?