### PR TITLE
Support reading body from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ This action was created to help facilitate a GitHub Actions "ChatOps" solution i
 | `issue-number` | The number of the issue or pull request in which to create a comment. | |
 | `comment-id` | The id of the comment to update. | |
 | `body` | The comment body. | |
+| `file` | The path to a file that can be read as `body`. Use either `file` or `body`, but not both. | |
+| `fileEncoding` | The encoding of the file provided as `file`. | `utf8` |
 | `edit-mode` | The mode when updating a comment, `replace` or `append`. | `append` |
 | `reactions` | A comma separated list of reactions to add to the comment. (`+1`, `-1`, `laugh`, `confused`, `heart`, `hooray`, `rocket`, `eyes`) | |
 
@@ -158,23 +160,12 @@ If required, the create and update steps can be separated for greater control.
 
 ### Setting the comment body from a file
 
-This example shows how file content can be read into a variable and passed to the action.
-The content must be [escaped to preserve newlines](https://github.community/t/set-output-truncates-multiline-strings/16852/3).
-
 ```yml
-      - id: get-comment-body
-        run: |
-          body="$(cat comment-body.txt)"
-          body="${body//'%'/'%25'}"
-          body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}" 
-          echo "::set-output name=body::$body"
-
       - name: Create comment
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: 1
-          body: ${{ steps.get-comment-body.outputs.body }}
+          file: 'comment-body.txt'
 ```
 
 ### Using a markdown template

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,8 @@ inputs:
     description: 'The id of the comment to update.'
   body:
     description: 'The comment body.'
+  file:
+    description: 'The path to a file that can be read as `body`. Use either `file` or `body`, but not both.'
   edit-mode:
     description: 'The mode when updating a comment, "replace" or "append".'
   reaction-type:
@@ -25,5 +27,5 @@ runs:
   using: 'node16'
   main: 'dist/index.js'
 branding:
-  icon: 'message-square'  
+  icon: 'message-square'
   color: 'gray-dark'


### PR DESCRIPTION
Ran into an issue where the body stored in the environment variable was throwing an error saying `Error: Argument list too long` (similar to https://github.com/peter-evans/create-or-update-comment/issues/96).

Added support for `file` and `fileEncoding` arguments which can be passed in order to allow accessing the body directly from files, bypassing the need to store the body as a variable and escaping it. This also removes the restriction of the body content being too long to be supported by `sh`.