### PR TITLE
Truncate long comment bodies during comment update too

### DIFF
--- a/src/create-or-update-comment.ts
+++ b/src/create-or-update-comment.ts
@@ -118,6 +118,17 @@ function appendSeparatorTo(body: string, separator: string): string {
   }
 }
 
+function truncateBody(
+  body: string
+) {
+  // 65536 characters is the maximum allowed for issue comments.
+  if (body.length > 65536) {
+    core.warning(`Comment body is too long. Truncating to 65536 characters.`)
+    return body.substring(0, 65536)
+  }
+  return body
+}
+
 async function createComment(
   octokit,
   owner: string,
@@ -125,11 +136,7 @@ async function createComment(
   issueNumber: number,
   body: string
 ): Promise<number> {
-  // 65536 characters is the maximum allowed for issue comments.
-  if (body.length > 65536) {
-    core.warning(`Comment body is too long. Truncating to 65536 characters.`)
-    body = body.substring(0, 65536)
-  }
+  body = truncateBody(body);
 
   const {data: comment} = await octokit.rest.issues.createComment({
     owner: owner,
@@ -164,7 +171,7 @@ async function updateComment(
         appendSeparator
       )
     }
-    commentBody = commentBody + body
+    commentBody = truncateBody(commentBody + body)
     core.debug(`Comment body: ${commentBody}`)
     await octokit.rest.issues.updateComment({
       owner: owner,

--- a/src/create-or-update-comment.ts
+++ b/src/create-or-update-comment.ts
@@ -118,9 +118,7 @@ function appendSeparatorTo(body: string, separator: string): string {
   }
 }
 
-function truncateBody(
-  body: string
-) {
+function truncateBody(body: string) {
   // 65536 characters is the maximum allowed for issue comments.
   if (body.length > 65536) {
     core.warning(`Comment body is too long. Truncating to 65536 characters.`)
@@ -136,7 +134,7 @@ async function createComment(
   issueNumber: number,
   body: string
 ): Promise<number> {
-  body = truncateBody(body);
+  body = truncateBody(body)
 
   const {data: comment} = await octokit.rest.issues.createComment({
     owner: owner,


### PR DESCRIPTION
#182 truncated comment bodies during comment creation only. But it doesn't truncate comment bodies during update.

This fix also truncates comment update bodies that are too long (in both the replace and append cases)

I'm working on a private project that uses this action, it fails to update a comment because the update body is too long. This PR is an extremely crap proof of concept that has unblocked my project.

I realise it might be a bad developer experience to silently drop text that someone is trying to append to a comment.