### PR TITLE
add truncate warning to body of comment

### DIFF
--- a/src/create-or-update-comment.ts
+++ b/src/create-or-update-comment.ts
@@ -120,9 +120,10 @@ function appendSeparatorTo(body: string, separator: string): string {
 
 function truncateBody(body: string) {
   // 65536 characters is the maximum allowed for issue comments.
+  let truncateWarning = "*Comment has been truncated*"
   if (body.length > 65536) {
     core.warning(`Comment body is too long. Truncating to 65536 characters.`)
-    return body.substring(0, 65536)
+    return body.substring(0, 65536-truncateWarning.length) + truncateWarning
   }
   return body
 }

--- a/src/create-or-update-comment.ts
+++ b/src/create-or-update-comment.ts
@@ -120,7 +120,7 @@ function appendSeparatorTo(body: string, separator: string): string {
 
 function truncateBody(body: string) {
   // 65536 characters is the maximum allowed for issue comments.
-  let truncateWarning = "*Comment has been truncated*"
+  let truncateWarning = "...*[Comment body truncated]*"
   if (body.length > 65536) {
     core.warning(`Comment body is too long. Truncating to 65536 characters.`)
     return body.substring(0, 65536-truncateWarning.length) + truncateWarning


### PR DESCRIPTION
Auto-truncating comments is nice, but IMO it would be better to also add a line to the end of the comment indicating that it has been truncated. Otherwise, the only way to tell it's been truncated is to check for the warning in the Workflow summary.