### PR TITLE
Adds recreate edit mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ A GitHub action to create or update an issue or pull request comment.
 | `comment-id` | The id of the comment to update. | |
 | `body` | The comment body. Cannot be used in conjunction with `body-path`. | |
 | `body-path` | The path to a file containing the comment body. Cannot be used in conjunction with `body`. | |
-| `edit-mode` | The mode when updating a comment, `replace` or `append`. | `append` |
+| `edit-mode` | The mode when updating a comment, `append`, or `replace`, or `recreate` . | `append` |
 | `append-separator` | The separator to use when appending to an existing comment. (`newline`, `space`, `none`) | `newline` |
 | `reactions` | A comma or newline separated list of reactions to add to the comment. (`+1`, `-1`, `laugh`, `confused`, `heart`, `hooray`, `rocket`, `eyes`) | |
 | `reactions-edit-mode` | The mode when updating comment reactions, `replace` or `append`. | `append` |

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ inputs:
   body-file:
     description: 'Deprecated in favour of `body-path`.'
   edit-mode:
-    description: 'The mode when updating a comment, "replace" or "append".'
+    description: 'The mode when updating a comment, "append", or "replace", or "recreate".'
     default: 'append'
   append-separator:
     description: 'The separator to use when appending to an existing comment. (`newline`, `space`, `none`)'

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ async function run(): Promise<void> {
     }
     core.debug(`Inputs: ${inspect(inputs)}`)
 
-    if (!['append', 'replace'].includes(inputs.editMode)) {
+    if (!['append', 'replace', 'recreate'].includes(inputs.editMode)) {
       throw new Error(`Invalid edit-mode '${inputs.editMode}'.`)
     }
 


### PR DESCRIPTION
While I was using this helpful action in my workflows, I noticed that the comments created and later updated by it could "get lost" in the records of a PR if this gets large enough, which in some cases could harm the dev/review experience. With this PR, I'd like to propose something that could add to it in that sense. 

A behavior that could solve the problem would be what tools' bots, such as Sonar, do, which recreates the comments at the end of each check so they are always close to the most recent PR activity logs. Obviously, it's possible to solve the issue directly in my workflow, even though this would generally be done by using other actions from the marketplace or perhaps by using the API directly. However, I thought: "Why not try to contribute by adding support for this 'editing mode'?"

If this goes against what was ideal for the action, feel free to reject the PR outright or ask any questions you may have. Thank you 🙂